### PR TITLE
Change default shutdown/reboot commands

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -25,7 +25,7 @@
       <default>systemctl suspend</default>
     </entry>
     <entry name="restartSettings" type="String">
-      <default>/sbin/reboot</default>
+      <default>qdbus org.kde.ksmserver /KSMServer logout 0 1 2</default>
     </entry>
     <entry name="shutDownSettings" type="String">
       <default>qdbus org.kde.ksmserver /KSMServer logout 0 2 2</default>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -28,7 +28,7 @@
       <default>/sbin/reboot</default>
     </entry>
     <entry name="shutDownSettings" type="String">
-      <default>/sbin/shutdown now</default>
+      <default>qdbus org.kde.ksmserver /KSMServer logout 0 2 2</default>
     </entry>
     <entry name="lockScreenSettings" type="String">
       <default>qdbus org.freedesktop.ScreenSaver /ScreenSaver Lock</default>


### PR DESCRIPTION
I've changed the default shutdown/reboot commands in favor for the `qdbus` command because it will shutdown more elegantly.